### PR TITLE
Added Amazon Linux 2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,27 @@ $ git clone git@github.com:nozaq/amazon-linux-cis.git .
 $ python ./amazon-linux-cis
 ```
 
+## Available Arguments
+Argument (default value) | What it does 
+------------ | -------------
+--time (169.254.169.123) | Specify the upstream time server
+--chrony *boolean* (true) | Use chrony for time synchronization
+--no-backup | Automatic config backup is disabled
+--clients *comma seperate list* | Specify a comma separated list of hostnames and host IP addresses
+-v --verbose | Enable verbose logging of utility
+--disable-tcp-wrappers | Disable installation of TCP Wrappers package
+--disable-pam | Disable installation of TCP Wrappers package
+--disable-iptables | Disable the hardening of the PAM module
+--disable-mount-options | Disable replacing the default */etc/fstab* mounting config file
+
+
+## Amazon Linux 2 Support
+Although the differences between Amazon Linux and Amazon Linux 2 are extensive ([listed here](https://aws.amazon.com/amazon-linux-2/faqs/)), the majority of the changes to reach CIS compliance for Amazon Linux 2 are minor. Here's the minimum required command line needed to install the hardening on Amazon Linux 2 instances.
+
+```
+python ./amazon-linux-cis --disable-mount-options
+```
+
 ## Tested Environments
-- Amazon Linux 2017.09
+- Amazon Linux - 2017.09
+- Amazon Linux 2 - 2017.12

--- a/__main__.py
+++ b/__main__.py
@@ -333,7 +333,7 @@ def configure_iptables():
         'iptables -A INPUT -p udp -m state --state ESTABLISHED -j ACCEPT',
         'iptables -A INPUT -p icmp -m state --state ESTABLISHED -j ACCEPT',
         'iptables -A INPUT -p tcp --dport 22 -m state --state NEW -j ACCEPT',
-        'service iptables save'
+        'iptables-save'
     ])
 
 

--- a/__main__.py
+++ b/__main__.py
@@ -530,6 +530,8 @@ def main():
                         help='disable pam')
     parser.add_argument('--disable-iptables', action='store_true',
                         help='disable iptables')
+    parser.add_argument('--disable-mount-options', action='store_true',
++                        help='disable set mount options')
 
     args = parser.parse_args()
 
@@ -556,7 +558,8 @@ def main():
 
     # 1 Initial Setup
     disable_unused_filesystems()
-    set_mount_options()
+    if not args.disable_mount_options:
++        set_mount_options()
     ensure_sticky_bit()
     disable_automounting()
     enable_aide()

--- a/__main__.py
+++ b/__main__.py
@@ -57,7 +57,7 @@ def ensure_sticky_bit():
         return 1
 
 
-def disable_automounitng():
+def disable_automounting():
     """1.1.19 Disable Automounting"""
     Service('autofs').disable()
 
@@ -558,7 +558,7 @@ def main():
     disable_unused_filesystems()
     set_mount_options()
     ensure_sticky_bit()
-    disable_automounitng()
+    disable_automounting()
     enable_aide()
     secure_boot_settings()
     apply_process_hardenings()

--- a/__main__.py
+++ b/__main__.py
@@ -559,7 +559,7 @@ def main():
     # 1 Initial Setup
     disable_unused_filesystems()
     if not args.disable_mount_options:
-+        set_mount_options()
+        set_mount_options()
     ensure_sticky_bit()
     disable_automounting()
     enable_aide()

--- a/__main__.py
+++ b/__main__.py
@@ -531,7 +531,7 @@ def main():
     parser.add_argument('--disable-iptables', action='store_true',
                         help='disable iptables')
     parser.add_argument('--disable-mount-options', action='store_true',
-+                        help='disable set mount options')
+                        help='disable set mount options')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
The following additional changes to the code will allow for this utility to be run against Amazon Linux 2 to harden it against CIS compliance as intended. It's been backward compatible tested again Amazon Linux as well (2018.03). A new argument needed to be created to avoid deploying the mounting config file (/etc/fstab) as this didn't work in Amazon Linux 2.